### PR TITLE
Io refactor

### DIFF
--- a/src/System/bus.jl
+++ b/src/System/bus.jl
@@ -45,7 +45,8 @@ function add_system_elements!(m::JuMP.Model, ses::Buses)
     m[LOAD] = @variable(m, [1:num_buses], base_name = String(LOAD))
     m[DEFICIT] = @variable(m, [1:num_buses], base_name = String(DEFICIT))
 
-    @constraint(m, m[DEFICIT] .>= 0)
+    set_lower_bound.(m[DEFICIT], 0)
+
     return nothing
 end
 

--- a/src/System/line.jl
+++ b/src/System/line.jl
@@ -57,17 +57,21 @@ function add_system_elements!(m::JuMP.Model, ses::Lines)
     m[DIRECT_EXCHANGE] = @variable(
         m, [n = 1:num_lines], base_name = String(DIRECT_EXCHANGE)
     )
+    for n in 1:num_lines
+        set_lower_bound(m[DIRECT_EXCHANGE][n], 0)
+        set_upper_bound(m[DIRECT_EXCHANGE][n], ses.entities[n].capacity)
+    end
+    
     m[REVERSE_EXCHANGE] = @variable(
         m, [n = 1:num_lines], base_name = String(REVERSE_EXCHANGE)
     )
+    for n in 1:num_lines
+        set_lower_bound(m[REVERSE_EXCHANGE][n], 0)
+        set_upper_bound(m[REVERSE_EXCHANGE][n], ses.entities[n].capacity)
+    end
+        
     m[NET_EXCHANGE] = @variable(m, [n = 1:num_lines], base_name = String(NET_EXCHANGE))
 
-    @constraint(
-        m, [n = 1:num_lines], 0 <= m[DIRECT_EXCHANGE][n] <= ses.entities[n].capacity
-    )
-    @constraint(
-        m, [n = 1:num_lines], 0 <= m[REVERSE_EXCHANGE][n] <= ses.entities[n].capacity
-    )
     @constraint(m, m[NET_EXCHANGE] .== m[DIRECT_EXCHANGE] - m[REVERSE_EXCHANGE])
 end
 

--- a/src/System/line.jl
+++ b/src/System/line.jl
@@ -70,9 +70,7 @@ function add_system_elements!(m::JuMP.Model, ses::Lines)
         set_upper_bound(m[REVERSE_EXCHANGE][n], ses.entities[n].capacity)
     end
         
-    m[NET_EXCHANGE] = @variable(m, [n = 1:num_lines], base_name = String(NET_EXCHANGE))
-
-    @constraint(m, m[NET_EXCHANGE] .== m[DIRECT_EXCHANGE] - m[REVERSE_EXCHANGE])
+    m[NET_EXCHANGE] = @expression(m, m[DIRECT_EXCHANGE] - m[REVERSE_EXCHANGE])
 end
 
 # GENERAL METHODS --------------------------------------------------------------------------

--- a/src/System/thermal.jl
+++ b/src/System/thermal.jl
@@ -80,14 +80,11 @@ function add_system_elements!(m::JuMP.Model, ses::Thermals)
     m[THERMAL_GENERATION] = @variable(
         m, [n = 1:num_thermals], base_name = String(THERMAL_GENERATION)
     )
+    for n in 1:num_thermals
+        set_lower_bound(m[THERMAL_GENERATION][n], ses.entities[n].min_generation)
+        set_upper_bound(m[THERMAL_GENERATION][n], ses.entities[n].max_generation)
+    end
 
-    @constraint(
-        m,
-        [n = 1:num_thermals],
-        ses.entities[n].min_generation <=
-            m[THERMAL_GENERATION][n] <=
-            ses.entities[n].max_generation
-    )
     return nothing
 end
 


### PR DESCRIPTION
All System variable bounds are now set via the dedicated `set_lower_bound` and `set_upper_bound` instead of the generic `@constraint`

Additionally, `NET_EXCHANGE`, `OUTFLOW` and `HYDRO_GENERATION` were turned into `AffineExpression`s. In the latter's case, the minimum and maximum generation bounds were moved to `TURBINED_FLOW`, taking productivity into account